### PR TITLE
WLAN interface control

### DIFF
--- a/stage2/02-net-tweaks/01-run.sh
+++ b/stage2/02-net-tweaks/01-run.sh
@@ -27,6 +27,9 @@ install -m 644 -v files/sysctl.conf "${ROOTFS_DIR}/etc/"
 echo "Installing unique UUID script"
 install -m 755 -v files/unique_ssid.py "${ROOTFS_DIR}/opt/"
 
+echo "Installing 72-wlan-geo-dependent.rules"
+install -m 644 -v files/72-wlan-geo-dependent.rules "${ROOTFS_DIR}/etc/udev/rules.d/"
+
 echo "Wireless access point configuration complete"
 
 on_chroot << EOF

--- a/stage2/02-net-tweaks/files/72-wlan-geo-dependent.rules
+++ b/stage2/02-net-tweaks/files/72-wlan-geo-dependent.rules
@@ -1,0 +1,3 @@
+# Force onboard WiFi interface to use wlan1 and allow wlan0 for USB WiFi chip
+
+ACTION=="add", SUBSYSTEM=="net", DRIVERS=="brcmfmac", NAME="wlan1"

--- a/stage2/02-net-tweaks/files/hostapd.conf
+++ b/stage2/02-net-tweaks/files/hostapd.conf
@@ -1,5 +1,4 @@
 interface=wlan0
-driver=nl80211
 ssid=MissionMule
 hw_mode=g
 channel=7

--- a/stage2/02-net-tweaks/files/wpa_supplicant.conf
+++ b/stage2/02-net-tweaks/files/wpa_supplicant.conf
@@ -1,2 +1,7 @@
 ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
 update_config=1
+
+network={
+  ssid="DC"
+  psk="urrutias"
+}


### PR DESCRIPTION
This pull request forces onboard Wi-Fi to the `wlan1` interface thereby leaving `wlan0` available to be controlled by an external Wi-Fi chip over USB. Therefore, the access point from the Pi is broadcasted over the more powerful interface: the USB. Meanwhile, the onboard Wi-Fi is still available to connect to external Wi-Fi networks for package updates, debugging, etc. 

Furthermore, the `DC` network was added to `wpa_supplicant.conf` so new `muleOS` images will immediately connect to our local Mission Mule development machines for debugging.